### PR TITLE
Feature/mfe footer update

### DIFF
--- a/dist/components/styles/Footer.css
+++ b/dist/components/styles/Footer.css
@@ -253,7 +253,7 @@ body {
   }
 
   .logo-wrapper>.footer-colophon {
-    margin-left: 0;
+    margin-left: 15px;
     margin-top: 12px;
     flex-wrap: wrap;
     gap: 12px;
@@ -262,6 +262,13 @@ body {
   .footer-colophon .footer-link {
     margin-right: 16px;
     font-size: 18px;
+    position: relative;
+    top: -1px;
+  }
+
+  .footer-social-icons {
+    margin-right: 0;
+    justify-content: center;
   }
 
   .footer-bottom {
@@ -279,5 +286,30 @@ body {
 
   .footer-colophon .footer-link {
     font-size: 16px;
+  }
+}
+
+@media (max-width: 425px) {
+  .logo-image {
+    height: 30px;
+  }
+
+  .footer-container {
+    padding: 0 10px;
+  }
+
+  .logo-wrapper>.footer-colophon {
+    flex-wrap: nowrap;
+  }
+
+  .footer-colophon .footer-link {
+    font-size: 13px;
+    margin-right: 8px;
+  }
+}
+
+@media (max-width: 320px) {
+  .footer-colophon .footer-link {
+    font-size: 12px;
   }
 }

--- a/src/components/styles/Footer.css
+++ b/src/components/styles/Footer.css
@@ -253,7 +253,7 @@ body {
   }
 
   .logo-wrapper>.footer-colophon {
-    margin-left: 0;
+    margin-left: 15px;
     margin-top: 12px;
     flex-wrap: wrap;
     gap: 12px;
@@ -262,6 +262,13 @@ body {
   .footer-colophon .footer-link {
     margin-right: 16px;
     font-size: 18px;
+    position: relative;
+    top: -1px;
+  }
+
+  .footer-social-icons {
+    margin-right: 0;
+    justify-content: center;
   }
 
   .footer-bottom {
@@ -279,5 +286,30 @@ body {
 
   .footer-colophon .footer-link {
     font-size: 16px;
+  }
+}
+
+@media (max-width: 425px) {
+  .logo-image {
+    height: 30px;
+  }
+
+  .footer-container {
+    padding: 0 10px;
+  }
+
+  .logo-wrapper>.footer-colophon {
+    flex-wrap: nowrap;
+  }
+
+  .footer-colophon .footer-link {
+    font-size: 13px;
+    margin-right: 8px;
+  }
+}
+
+@media (max-width: 320px) {
+  .footer-colophon .footer-link {
+    font-size: 12px;
   }
 }


### PR DESCRIPTION
- Add 15px left margin to footer colophon for better alignment
- Position footer links 1px higher with relative positioning
- Center social icons and remove right margin on mobile
- Add 425px breakpoint: reduce logo to 30px, adjust padding to 10px, prevent colophon wrapping, decrease link font to 13px with 8px margins
- Add 320px breakpoint: further reduce link font size to 12px